### PR TITLE
Enable inline scripts by adding script-src to CSP header

### DIFF
--- a/2fa-form-html.go
+++ b/2fa-form-html.go
@@ -95,7 +95,7 @@ func (m *postauth2fa) show2FAForm(w http.ResponseWriter, formData formData) {
 
 	// Set the Content-Type and Content-Security-Policy headers with nonce
 	w.Header().Set("Content-Type", "text/html")
-    w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'self' 'nonce-"+nonce+"'; script-src 'self' 'nonce-"+nonce+"'; form-action 'self';")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'; style-src 'self' 'nonce-"+nonce+"'; script-src 'self' 'nonce-"+nonce+"'; form-action 'self';")
 	w.WriteHeader(http.StatusOK)
 
 	// Execute the template and write the output to the response


### PR DESCRIPTION
I'm using a script to make a pretty Caddy looking 2FA form 😉 
<img width="1326" height="759" alt="image" src="https://github.com/user-attachments/assets/74914e11-bbcb-4752-8aee-ec20d7ebddac" />
