### PR TITLE
Alternative form matching file_server browse theme

### DIFF
--- a/alternative-2fa-form.html
+++ b/alternative-2fa-form.html
@@ -284,7 +284,7 @@
                 </div>
 
             <input type="hidden" id="dynamic-code-length" value="{{ .TOTPCodeLength }}">
-            <input type="hidden" id="hidden-code" name="totp_code" value="">
+            <input type="hidden" id="hidden-code" name="totp_code" value="" autocomplete="one-time-code">
         </div>
     </form>
     {{- if .ErrorMessage }}


### PR DESCRIPTION
Here's a pretty alternative to the default form in the theme of Caddy's built in `file_server browse`.
Happy to just keep this PR for others, or to merge, or even replace the default form - up to you!
Gemini's code isn't great but it works and this is a great candidate for vibe coding ✨

_Ignore the your your in the screencast/shot  - this is fixed in the code_

https://github.com/user-attachments/assets/2018c8de-2422-4476-a560-9fff110d1744

<img width="1126" height="806" alt="Screenshot 2025-10-12 145520" src="https://github.com/user-attachments/assets/ad4a2689-98f4-4752-a007-a66c59563b4b" />
