### PR TITLE
Add unit tests and deterministic time handling for 2FA/JWT logic

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    allow:
+      - dependency-type: "direct"

--- a/caddyfile_test.go
+++ b/caddyfile_test.go
@@ -1,0 +1,110 @@
+package postauth2fa
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2/caddyconfig/caddyfile"
+)
+
+func TestUnmarshalCaddyfile(t *testing.T) {
+	t.Parallel()
+
+	d := caddyfile.NewTestDispenser(`
+postauth_2fa {
+	cookie_domain example.com
+	cookie_name custom_sess
+	cookie_path /secure
+	encryption_key enc-key
+	form_template /tmp/2fa.html
+	form_response_header X-2FA challenge
+	ip_binding false
+	secrets_file_path /tmp/secrets.json
+	session_inactivity_timeout 90m
+	sign_key sign-key
+	totp_code_length 8
+	channel_suffix _admin
+	username_placeholder {http.auth.user.id}
+}
+`)
+
+	var m postauth2fa
+	if err := m.UnmarshalCaddyfile(d); err != nil {
+		t.Fatalf("UnmarshalCaddyfile() error = %v", err)
+	}
+
+	if m.CookieDomain != "example.com" ||
+		m.CookieName != "custom_sess" ||
+		m.CookiePath != "/secure" ||
+		m.EncryptionKey != "enc-key" ||
+		m.FormTemplateFile != "/tmp/2fa.html" ||
+		m.FormResponseHeaderName != "X-2FA" ||
+		m.FormResponseHeaderValue != "challenge" ||
+		m.IPBinding != "false" ||
+		m.SecretsFilePath != "/tmp/secrets.json" ||
+		m.SessionInactivityTimeout != 90*time.Minute ||
+		m.SignKey != "sign-key" ||
+		m.TOTPCodeLength != 8 ||
+		m.ChannelSuffix != "_admin" ||
+		m.UsernamePlaceholder != "{http.auth.user.id}" {
+		t.Fatalf("unexpected parsed module: %+v", m)
+	}
+}
+
+func TestUnmarshalCaddyfileErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name: "unknown subdirective",
+			input: `
+postauth_2fa {
+	unknown value
+}
+`,
+			wantErr: "unknown subdirective",
+		},
+		{
+			name: "invalid duration",
+			input: `
+postauth_2fa {
+	session_inactivity_timeout later
+}
+`,
+			wantErr: "invalid session_inactivity_timeout duration",
+		},
+		{
+			name: "invalid totp code length",
+			input: `
+postauth_2fa {
+	totp_code_length 7
+}
+`,
+			wantErr: "eiher 6 or 8 digits are allowed",
+		},
+		{
+			name: "too many form response header args",
+			input: `
+postauth_2fa {
+	form_response_header X-2FA true extra
+}
+`,
+			wantErr: "at most two arguments",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var m postauth2fa
+			err := m.UnmarshalCaddyfile(caddyfile.NewTestDispenser(tt.input))
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("UnmarshalCaddyfile() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/helpers_test.go
+++ b/helpers_test.go
@@ -1,0 +1,129 @@
+package postauth2fa
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"html/template"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/pquerna/otp"
+	"github.com/pquerna/otp/totp"
+	"go.uber.org/zap"
+)
+
+var (
+	testSignKeyBytes       = []byte("0123456789abcdef0123456789abcdef")
+	testEncryptionKeyBytes = []byte("abcdef0123456789abcdef0123456789")
+)
+
+func newTestModule(t *testing.T) *postauth2fa {
+	t.Helper()
+
+	now := time.Now().UTC()
+	formTemplate := template.Must(template.New("test").Parse("<html>{{.Username}}|{{.ErrorMessage}}|{{.TOTPCodeLength}}|{{.ChannelSuffix}}</html>"))
+
+	return &postauth2fa{
+		SessionInactivityTimeout: time.Hour,
+		CookieName:               "cpa_sess",
+		CookiePath:               "/",
+		UsernamePlaceholder:      "{http.auth.user.id}",
+		IPBinding:                "true",
+		TOTPCodeLength:           6,
+		signKeyBytes:             append([]byte(nil), testSignKeyBytes...),
+		encryptionKeyBytes:       append([]byte(nil), testEncryptionKeyBytes...),
+		secretsLoadMutex:         &sync.Mutex{},
+		formTemplate:             formTemplate,
+		logger:                   zap.NewNop(),
+		timeNow: func() time.Time {
+			return now
+		},
+	}
+}
+
+func testKeyB64(key []byte) string {
+	return base64.StdEncoding.EncodeToString(key)
+}
+
+func newRequestWithContext(method, target, username, origURI, clientIP, remoteAddr string, body *http.Request) *http.Request {
+	var req *http.Request
+	if body != nil {
+		req = body
+	} else {
+		req = httptest.NewRequest(method, target, nil)
+	}
+
+	if remoteAddr != "" {
+		req.RemoteAddr = remoteAddr
+	}
+
+	repl := caddyhttp.NewTestReplacer(req)
+	req = caddyhttp.PrepareRequest(req, repl, httptest.NewRecorder(), &caddyhttp.Server{})
+
+	if username != "" {
+		repl.Set("http.auth.user.id", username)
+	}
+	if origURI != "" {
+		repl.Set("http.request.orig_uri", origURI)
+	}
+	if clientIP != "" {
+		caddyhttp.SetVar(req.Context(), "client_ip", clientIP)
+	} else {
+		delete(req.Context().Value(caddyhttp.VarsCtxKey).(map[string]any), "client_ip")
+	}
+
+	return req
+}
+
+func signedTokenString(t *testing.T, m *postauth2fa, claims jwt.MapClaims) string {
+	t.Helper()
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	signed, err := token.SignedString(m.signKeyBytes)
+	if err != nil {
+		t.Fatalf("sign token: %v", err)
+	}
+	return signed
+}
+
+func encryptSecretForTest(t *testing.T, plaintext string, key []byte) string {
+	t.Helper()
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatalf("new cipher: %v", err)
+	}
+	aesgcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatalf("new gcm: %v", err)
+	}
+
+	nonce := make([]byte, aesgcm.NonceSize())
+	for i := range nonce {
+		nonce[i] = byte(i + 1)
+	}
+
+	ciphertext := aesgcm.Seal(nil, nonce, []byte(plaintext), nil)
+	return base64.StdEncoding.EncodeToString(append(nonce, ciphertext...))
+}
+
+func generateTOTPCodeForTest(t *testing.T, secret string, digits int, now time.Time) string {
+	t.Helper()
+
+	code, err := totp.GenerateCodeCustom(secret, now, totp.ValidateOpts{
+		Period:    30,
+		Skew:      1,
+		Digits:    otp.Digits(digits),
+		Algorithm: otp.AlgorithmSHA1,
+	})
+	if err != nil {
+		t.Fatalf("generate totp code: %v", err)
+	}
+	return code
+}

--- a/postauth2fa.go
+++ b/postauth2fa.go
@@ -122,6 +122,9 @@ type postauth2fa struct {
 	// logger provides structured logging for the module.
 	// It's initialized in the Provision method and used throughout the module for debug information.
 	logger *zap.Logger
+
+	// timeNow returns the current time and can be overridden in tests.
+	timeNow func() time.Time
 }
 
 // CaddyModule returns the Caddy module information.
@@ -330,7 +333,7 @@ func (m *postauth2fa) ServeHTTP(w http.ResponseWriter, r *http.Request, next cad
 	}
 
 	// Validate the TOTP code with the user's secret and code length.
-	valid, err := validateTOTPCode(totpCode, secret, codeLength)
+	valid, err := validateTOTPCodeAtTime(totpCode, secret, codeLength, m.now().UTC())
 	if !valid || err != nil {
 		// If validation fails, log an invalid TOTP attempt for monitoring tools like fail2ban.
 		logger.Warn("Invalid TOTP attempt", zap.Error(err))
@@ -379,14 +382,21 @@ func isValidTOTPCodeLength(length int) bool {
 	return length == int(otp.DigitsSix) || length == int(otp.DigitsEight)
 }
 
-func validateTOTPCode(code, secret string, codeLength int) (bool, error) {
+func validateTOTPCodeAtTime(code, secret string, codeLength int, now time.Time) (bool, error) {
 	opts := totp.ValidateOpts{
 		Period:    30,
 		Skew:      1,
 		Digits:    otp.Digits(codeLength),
 		Algorithm: otp.AlgorithmSHA1,
 	}
-	return totp.ValidateCustom(code, secret, time.Now().UTC(), opts)
+	return totp.ValidateCustom(code, secret, now, opts)
+}
+
+func (m *postauth2fa) now() time.Time {
+	if m.timeNow != nil {
+		return m.timeNow()
+	}
+	return time.Now()
 }
 
 // Interface guards to ensure postauth2fa implements the necessary interfaces.

--- a/postauth2fa_test.go
+++ b/postauth2fa_test.go
@@ -1,0 +1,465 @@
+package postauth2fa
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caddyserver/caddy/v2"
+	"github.com/caddyserver/caddy/v2/modules/caddyhttp"
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestValidate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*postauth2fa)
+		wantErr string
+	}{
+		{
+			name: "rejects non-positive timeout",
+			mutate: func(m *postauth2fa) {
+				m.SessionInactivityTimeout = 0
+			},
+			wantErr: "positive duration",
+		},
+		{
+			name: "rejects missing sign key",
+			mutate: func(m *postauth2fa) {
+				m.SignKey = ""
+			},
+			wantErr: "SignKey must be defined",
+		},
+		{
+			name: "rejects short sign key",
+			mutate: func(m *postauth2fa) {
+				m.signKeyBytes = []byte("too-short")
+			},
+			wantErr: "at least 32 bytes",
+		},
+		{
+			name: "rejects invalid encryption key length",
+			mutate: func(m *postauth2fa) {
+				m.EncryptionKey = "configured"
+				m.encryptionKeyBytes = []byte("short")
+			},
+			wantErr: "must be 32 bytes",
+		},
+		{
+			name: "rejects invalid response header prefix",
+			mutate: func(m *postauth2fa) {
+				m.FormResponseHeaderName = "2FA-Required"
+			},
+			wantErr: "must start with 'X-'",
+		},
+		{
+			name: "rejects invalid totp code length",
+			mutate: func(m *postauth2fa) {
+				m.TOTPCodeLength = 7
+			},
+			wantErr: "must be 6 or 8",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &postauth2fa{
+				SessionInactivityTimeout: time.Minute,
+				SignKey:                  testKeyB64(testSignKeyBytes),
+				signKeyBytes:             append([]byte(nil), testSignKeyBytes...),
+				TOTPCodeLength:           6,
+			}
+			tt.mutate(m)
+
+			err := m.Validate()
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Validate() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestProvisionSetsDefaultsAndDecodesKeys(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	signKeyFile := filepath.Join(dir, "sign-key.txt")
+	encryptionKeyFile := filepath.Join(dir, "encryption-key.txt")
+
+	if err := os.WriteFile(signKeyFile, []byte(testKeyB64(testSignKeyBytes)), 0o600); err != nil {
+		t.Fatalf("write sign key file: %v", err)
+	}
+	if err := os.WriteFile(encryptionKeyFile, []byte(testKeyB64(testEncryptionKeyBytes)), 0o600); err != nil {
+		t.Fatalf("write encryption key file: %v", err)
+	}
+
+	m := &postauth2fa{
+		SignKey:       "{file." + signKeyFile + "}",
+		EncryptionKey: "{file." + encryptionKeyFile + "}",
+	}
+
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	if m.CookieName != "cpa_sess" ||
+		m.CookiePath != "/" ||
+		m.SessionInactivityTimeout != time.Hour ||
+		m.TOTPCodeLength != 6 ||
+		m.UsernamePlaceholder != "{http.auth.user.id}" ||
+		m.IPBinding != "true" {
+		t.Fatalf("unexpected defaults after Provision(): %+v", m)
+	}
+	if m.secretsLoadMutex == nil {
+		t.Fatalf("secretsLoadMutex is nil after Provision()")
+	}
+	if !bytes.Equal(m.signKeyBytes, testSignKeyBytes) {
+		t.Fatalf("signKeyBytes = %q, want %q", m.signKeyBytes, testSignKeyBytes)
+	}
+	if !bytes.Equal(m.encryptionKeyBytes, testEncryptionKeyBytes) {
+		t.Fatalf("encryptionKeyBytes = %q, want %q", m.encryptionKeyBytes, testEncryptionKeyBytes)
+	}
+	if m.formTemplate == nil {
+		t.Fatalf("formTemplate is nil after Provision()")
+	}
+}
+
+func TestProvisionLoadsCustomTemplate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	templateFile := filepath.Join(dir, "custom-2fa.html")
+	if err := os.WriteFile(templateFile, []byte(`<html>custom {{.Username}} {{.ChannelSuffix}}</html>`), 0o600); err != nil {
+		t.Fatalf("write template file: %v", err)
+	}
+
+	m := &postauth2fa{
+		SignKey:          testKeyB64(testSignKeyBytes),
+		EncryptionKey:    testKeyB64(testEncryptionKeyBytes),
+		FormTemplateFile: templateFile,
+	}
+
+	if err := m.Provision(caddy.Context{}); err != nil {
+		t.Fatalf("Provision() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	if err := m.formTemplate.Execute(&buf, formData{Username: "alice", ChannelSuffix: "_admin"}); err != nil {
+		t.Fatalf("execute custom template: %v", err)
+	}
+	if got := buf.String(); got != "<html>custom alice _admin</html>" {
+		t.Fatalf("custom template output = %q, want %q", got, "<html>custom alice _admin</html>")
+	}
+}
+
+func TestProvisionErrorsOnInvalidKeys(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		m       *postauth2fa
+		wantErr string
+	}{
+		{
+			name: "invalid sign key",
+			m: &postauth2fa{
+				SignKey:       "%%%not-base64%%%",
+				EncryptionKey: testKeyB64(testEncryptionKeyBytes),
+			},
+			wantErr: "illegal base64 data",
+		},
+		{
+			name: "invalid encryption key",
+			m: &postauth2fa{
+				SignKey:       testKeyB64(testSignKeyBytes),
+				EncryptionKey: "%%%not-base64%%%",
+			},
+			wantErr: "illegal base64 data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.m.Provision(caddy.Context{})
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("Provision() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateSetsDefaultFormResponseHeaderValue(t *testing.T) {
+	t.Parallel()
+
+	m := &postauth2fa{
+		SessionInactivityTimeout: time.Minute,
+		SignKey:                  testKeyB64(testSignKeyBytes),
+		signKeyBytes:             append([]byte(nil), testSignKeyBytes...),
+		FormResponseHeaderName:   "X-2FA-Required",
+		TOTPCodeLength:           6,
+	}
+
+	if err := m.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if m.FormResponseHeaderValue != "true" {
+		t.Fatalf("FormResponseHeaderValue = %q, want %q", m.FormResponseHeaderValue, "true")
+	}
+}
+
+func TestServeHTTP(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		username   string
+		secret     userSecretEntry
+		request    func(*testing.T, *postauth2fa) *http.Request
+		assertions func(*testing.T, *httptest.ResponseRecorder, error, bool)
+	}{
+		{
+			name:     "passes through valid jwt session",
+			username: "alice",
+			secret:   userSecretEntry{TOTPSecret: "JBSWY3DPEHPK3PXP"},
+			request: func(t *testing.T, m *postauth2fa) *http.Request {
+				t.Helper()
+				req := newRequestWithContext(http.MethodGet, "https://example.com/secure", "alice", "/original", "203.0.113.10", "198.51.100.20:1234", nil)
+				req.AddCookie(&http.Cookie{
+					Name: m.CookieName,
+					Value: signedTokenString(t, m, jwt.MapClaims{
+						"username": "alice",
+						"clientIP": "203.0.113.10",
+						"iat":      m.now().Add(-5 * time.Minute).Unix(),
+						"exp":      m.now().Add(45 * time.Minute).Unix(),
+					}),
+				})
+				return req
+			},
+			assertions: func(t *testing.T, rec *httptest.ResponseRecorder, err error, nextCalled bool) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("ServeHTTP() error = %v", err)
+				}
+				if !nextCalled {
+					t.Fatalf("next handler was not called")
+				}
+			},
+		},
+		{
+			name:     "shows form on get without session",
+			username: "alice",
+			secret:   userSecretEntry{TOTPSecret: "JBSWY3DPEHPK3PXP"},
+			request: func(t *testing.T, _ *postauth2fa) *http.Request {
+				t.Helper()
+				return newRequestWithContext(http.MethodGet, "https://example.com/secure", "alice", "/original", "203.0.113.10", "198.51.100.20:1234", nil)
+			},
+			assertions: func(t *testing.T, rec *httptest.ResponseRecorder, err error, nextCalled bool) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("ServeHTTP() error = %v", err)
+				}
+				if nextCalled {
+					t.Fatalf("next handler should not have been called")
+				}
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200", rec.Code)
+				}
+				if !strings.Contains(rec.Body.String(), "alice") {
+					t.Fatalf("response body = %q, want username", rec.Body.String())
+				}
+			},
+		},
+		{
+			name:     "re-renders form when totp code missing",
+			username: "alice",
+			secret:   userSecretEntry{TOTPSecret: "JBSWY3DPEHPK3PXP"},
+			request: func(t *testing.T, _ *postauth2fa) *http.Request {
+				t.Helper()
+				form := url.Values{}
+				req := httptest.NewRequest(http.MethodPost, "https://example.com/secure", strings.NewReader(form.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				return newRequestWithContext(http.MethodPost, "https://example.com/secure", "alice", "/original", "203.0.113.10", "198.51.100.20:1234", req)
+			},
+			assertions: func(t *testing.T, rec *httptest.ResponseRecorder, err error, nextCalled bool) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("ServeHTTP() error = %v", err)
+				}
+				if nextCalled {
+					t.Fatalf("next handler should not have been called")
+				}
+				if rec.Code != http.StatusOK {
+					t.Fatalf("status = %d, want 200", rec.Code)
+				}
+			},
+		},
+		{
+			name:     "rejects invalid totp code",
+			username: "alice",
+			secret:   userSecretEntry{TOTPSecret: "JBSWY3DPEHPK3PXP"},
+			request: func(t *testing.T, _ *postauth2fa) *http.Request {
+				t.Helper()
+				form := url.Values{"totp_code": {"000000"}}
+				req := httptest.NewRequest(http.MethodPost, "https://example.com/secure", strings.NewReader(form.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				return newRequestWithContext(http.MethodPost, "https://example.com/secure", "alice", "/original", "203.0.113.10", "198.51.100.20:1234", req)
+			},
+			assertions: func(t *testing.T, rec *httptest.ResponseRecorder, err error, nextCalled bool) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("ServeHTTP() error = %v", err)
+				}
+				if nextCalled {
+					t.Fatalf("next handler should not have been called")
+				}
+				if !strings.Contains(rec.Body.String(), "Invalid TOTP code. Please try again.") {
+					t.Fatalf("response body = %q, want invalid TOTP error", rec.Body.String())
+				}
+			},
+		},
+		{
+			name:     "accepts valid totp code and redirects",
+			username: "alice",
+			secret:   userSecretEntry{TOTPSecret: "JBSWY3DPEHPK3PXP"},
+			request: func(t *testing.T, m *postauth2fa) *http.Request {
+				t.Helper()
+				code := generateTOTPCodeForTest(t, "JBSWY3DPEHPK3PXP", 6, m.now().UTC())
+				form := url.Values{"totp_code": {code}}
+				req := httptest.NewRequest(http.MethodPost, "https://example.com/secure", strings.NewReader(form.Encode()))
+				req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+				return newRequestWithContext(http.MethodPost, "https://example.com/secure", "alice", "/original?foo=bar", "203.0.113.10", "198.51.100.20:1234", req)
+			},
+			assertions: func(t *testing.T, rec *httptest.ResponseRecorder, err error, nextCalled bool) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("ServeHTTP() error = %v", err)
+				}
+				if nextCalled {
+					t.Fatalf("next handler should not have been called")
+				}
+				if rec.Code != http.StatusFound {
+					t.Fatalf("status = %d, want 302", rec.Code)
+				}
+				if location := rec.Header().Get("Location"); location != "/original?foo=bar" {
+					t.Fatalf("Location = %q, want %q", location, "/original?foo=bar")
+				}
+				if rec.Header().Get("Set-Cookie") == "" {
+					t.Fatalf("expected Set-Cookie header on successful TOTP validation")
+				}
+			},
+		},
+		{
+			name:     "shows configuration error for invalid per-user code length",
+			username: "alice",
+			secret:   userSecretEntry{TOTPSecret: "JBSWY3DPEHPK3PXP", TOTPCodeLength: 7},
+			request: func(t *testing.T, _ *postauth2fa) *http.Request {
+				t.Helper()
+				return newRequestWithContext(http.MethodGet, "https://example.com/secure", "alice", "/original", "203.0.113.10", "198.51.100.20:1234", nil)
+			},
+			assertions: func(t *testing.T, rec *httptest.ResponseRecorder, err error, nextCalled bool) {
+				t.Helper()
+				if err != nil {
+					t.Fatalf("ServeHTTP() error = %v", err)
+				}
+				if nextCalled {
+					t.Fatalf("next handler should not have been called")
+				}
+				if !strings.Contains(rec.Body.String(), "Invalid TOTP configuration. Please contact support.") {
+					t.Fatalf("response body = %q, want configuration error", rec.Body.String())
+				}
+			},
+		},
+		{
+			name:     "returns handler error when username missing",
+			username: "",
+			request: func(t *testing.T, _ *postauth2fa) *http.Request {
+				t.Helper()
+				return newRequestWithContext(http.MethodGet, "https://example.com/secure", "", "/original", "203.0.113.10", "198.51.100.20:1234", nil)
+			},
+			assertions: func(t *testing.T, _ *httptest.ResponseRecorder, err error, nextCalled bool) {
+				t.Helper()
+				if nextCalled {
+					t.Fatalf("next handler should not have been called")
+				}
+				var handlerErr caddyhttp.HandlerError
+				if !errors.As(err, &handlerErr) {
+					t.Fatalf("ServeHTTP() error = %v, want caddyhttp.HandlerError", err)
+				}
+				if handlerErr.StatusCode != http.StatusInternalServerError {
+					t.Fatalf("status code = %d, want 500", handlerErr.StatusCode)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestModule(t)
+			if tt.username != "" {
+				m.loadedUserSecrets = map[string]userSecretEntry{
+					tt.username: tt.secret,
+				}
+			}
+
+			req := tt.request(t, m)
+			rec := httptest.NewRecorder()
+			nextCalled := false
+			next := caddyhttp.HandlerFunc(func(w http.ResponseWriter, r *http.Request) error {
+				nextCalled = true
+				w.WriteHeader(http.StatusNoContent)
+				return nil
+			})
+
+			err := m.ServeHTTP(rec, req, next)
+			tt.assertions(t, rec, err, nextCalled)
+		})
+	}
+}
+
+func TestGetClientIP(t *testing.T) {
+	t.Parallel()
+
+	req := newRequestWithContext(http.MethodGet, "https://example.com", "alice", "/original", "203.0.113.10", "198.51.100.20:1234", nil)
+	if got := getClientIP(req.Context(), req.RemoteAddr); got != "203.0.113.10" {
+		t.Fatalf("getClientIP() = %q, want %q", got, "203.0.113.10")
+	}
+
+	req = newRequestWithContext(http.MethodGet, "https://example.com", "alice", "/original", "", "198.51.100.20:1234", nil)
+	if got := getClientIP(req.Context(), req.RemoteAddr); got != "198.51.100.20" {
+		t.Fatalf("getClientIP() fallback = %q, want %q", got, "198.51.100.20")
+	}
+
+	req = newRequestWithContext(http.MethodGet, "https://example.com", "alice", "/original", "", "invalid-remote-addr", nil)
+	if got := getClientIP(req.Context(), req.RemoteAddr); got != "invalid-remote-addr" {
+		t.Fatalf("getClientIP() last resort = %q, want %q", got, "invalid-remote-addr")
+	}
+}
+
+func TestValidateTOTPCodeAtTime(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	code := generateTOTPCodeForTest(t, "JBSWY3DPEHPK3PXP", 6, now)
+
+	valid, err := validateTOTPCodeAtTime(code, "JBSWY3DPEHPK3PXP", 6, now)
+	if err != nil {
+		t.Fatalf("validateTOTPCodeAtTime() error = %v", err)
+	}
+	if !valid {
+		t.Fatalf("validateTOTPCodeAtTime() = false, want true")
+	}
+
+	valid, err = validateTOTPCodeAtTime(code, "JBSWY3DPEHPK3PXP", 8, now)
+	if err == nil && valid {
+		t.Fatalf("validateTOTPCodeAtTime() with wrong digits = true, want failure")
+	}
+}

--- a/secrets_test.go
+++ b/secrets_test.go
@@ -1,0 +1,139 @@
+package postauth2fa
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestGetSecretForUserPlaintext(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModule(t)
+	m.SecretsFilePath = writeSecretsFile(t, `{"alice":{"totp_secret":"JBSWY3DPEHPK3PXP","totp_code_length":8}}`)
+
+	secret, codeLength, err := m.getSecretForUser("alice")
+	if err != nil {
+		t.Fatalf("getSecretForUser() error = %v", err)
+	}
+	if secret != "JBSWY3DPEHPK3PXP" {
+		t.Fatalf("secret = %q, want %q", secret, "JBSWY3DPEHPK3PXP")
+	}
+	if codeLength != 8 {
+		t.Fatalf("codeLength = %d, want 8", codeLength)
+	}
+}
+
+func TestGetSecretForUserEncrypted(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModule(t)
+	encryptedSecret := encryptSecretForTest(t, "JBSWY3DPEHPK3PXP", m.encryptionKeyBytes)
+	m.SecretsFilePath = writeSecretsFile(t, `{"alice":{"totp_secret_encrypted":"`+encryptedSecret+`","totp_code_length":6}}`)
+
+	secret, codeLength, err := m.getSecretForUser("alice")
+	if err != nil {
+		t.Fatalf("getSecretForUser() error = %v", err)
+	}
+	if secret != "JBSWY3DPEHPK3PXP" {
+		t.Fatalf("secret = %q, want %q", secret, "JBSWY3DPEHPK3PXP")
+	}
+	if codeLength != 6 {
+		t.Fatalf("codeLength = %d, want 6", codeLength)
+	}
+}
+
+func TestGetSecretForUserCachesLoadedSecrets(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModule(t)
+	path := writeSecretsFile(t, `{"alice":{"totp_secret":"OLDSECRET"}}`)
+	m.SecretsFilePath = path
+
+	secret, _, err := m.getSecretForUser("alice")
+	if err != nil {
+		t.Fatalf("first getSecretForUser() error = %v", err)
+	}
+	if secret != "OLDSECRET" {
+		t.Fatalf("first secret = %q, want %q", secret, "OLDSECRET")
+	}
+
+	if err := os.WriteFile(path, []byte(`{"alice":{"totp_secret":"NEWSECRET"}}`), 0o600); err != nil {
+		t.Fatalf("rewrite secrets file: %v", err)
+	}
+
+	secret, _, err = m.getSecretForUser("alice")
+	if err != nil {
+		t.Fatalf("second getSecretForUser() error = %v", err)
+	}
+	if secret != "OLDSECRET" {
+		t.Fatalf("second secret = %q, want cached %q", secret, "OLDSECRET")
+	}
+}
+
+func TestGetSecretForUserErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		setup   func(*testing.T, *postauth2fa)
+		wantErr string
+	}{
+		{
+			name: "missing user",
+			setup: func(t *testing.T, m *postauth2fa) {
+				m.SecretsFilePath = writeSecretsFile(t, `{"alice":{"totp_secret":"JBSWY3DPEHPK3PXP"}}`)
+			},
+			wantErr: "no TOTP secret found for user: bob",
+		},
+		{
+			name: "invalid encryption key length",
+			setup: func(t *testing.T, m *postauth2fa) {
+				encryptedSecret := encryptSecretForTest(t, "JBSWY3DPEHPK3PXP", testEncryptionKeyBytes)
+				m.SecretsFilePath = writeSecretsFile(t, `{"alice":{"totp_secret_encrypted":"`+encryptedSecret+`"}}`)
+				m.encryptionKeyBytes = []byte("short")
+			},
+			wantErr: "encryption key is invalid",
+		},
+		{
+			name: "invalid json",
+			setup: func(t *testing.T, m *postauth2fa) {
+				m.SecretsFilePath = writeSecretsFile(t, `{"alice":`)
+			},
+			wantErr: "failed to decode secrets file",
+		},
+		{
+			name: "missing secret fields",
+			setup: func(t *testing.T, m *postauth2fa) {
+				m.SecretsFilePath = writeSecretsFile(t, `{"alice":{}}`)
+			},
+			wantErr: "no TOTP secret (plain or encrypted) found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestModule(t)
+			tt.setup(t, m)
+
+			_, _, err := m.getSecretForUser("bob")
+			if tt.name != "missing user" {
+				_, _, err = m.getSecretForUser("alice")
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("getSecretForUser() error = %v, want substring %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func writeSecretsFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write secrets file: %v", err)
+	}
+	return path
+}

--- a/sessions.go
+++ b/sessions.go
@@ -26,11 +26,12 @@ import (
 
 // createOrUpdateJWTCookie generates a new JWT with a specified client IP or updates an existing one, and logs the details.
 func (m *postauth2fa) createOrUpdateJWTCookie(w http.ResponseWriter, username, clientIP string) {
-	expiration := time.Now().Add(m.SessionInactivityTimeout)
+	now := m.now()
+	expiration := now.Add(m.SessionInactivityTimeout)
 	claims := jwt.MapClaims{
 		"username": username,
 		"clientIP": clientIP,
-		"iat":      time.Now().Unix(),
+		"iat":      now.Unix(),
 		"exp":      expiration.Unix(),
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
@@ -79,7 +80,7 @@ func (m *postauth2fa) hasValidJWTCookie(w http.ResponseWriter, r *http.Request, 
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return m.signKeyBytes, nil
-	}, jwt.WithValidMethods([]string{"HS256"})) // Enforcing HS256 only
+	}, jwt.WithValidMethods([]string{"HS256"}), jwt.WithTimeFunc(m.now)) // Enforcing HS256 only
 	if err != nil {
 		if errors.Is(err, jwt.ErrTokenExpired) {
 			// Log JWT expiration as info
@@ -110,7 +111,7 @@ func (m *postauth2fa) hasValidJWTCookie(w http.ResponseWriter, r *http.Request, 
 		// Extend session if less than 50% of inactivity timeout remains
 		expiration := time.Unix(int64(claims["exp"].(float64)), 0)
 		threshold := m.SessionInactivityTimeout / 2
-		if time.Until(expiration) < threshold {
+		if expiration.Sub(m.now()) < threshold {
 			logger.Debug("Extending session", zap.Time("expiration_before_extension", expiration))
 			m.createOrUpdateJWTCookie(w, username, clientIP)
 		}

--- a/sessions.go
+++ b/sessions.go
@@ -80,7 +80,10 @@ func (m *postauth2fa) hasValidJWTCookie(w http.ResponseWriter, r *http.Request, 
 			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
 		}
 		return m.signKeyBytes, nil
-	}, jwt.WithValidMethods([]string{"HS256"}), jwt.WithTimeFunc(m.now)) // Enforcing HS256 only
+	},
+		jwt.WithValidMethods([]string{"HS256"}), // Enforce HS256 only.
+		jwt.WithTimeFunc(m.now),                 // Use the module's time source for expiry validation.
+	)
 	if err != nil {
 		if errors.Is(err, jwt.ErrTokenExpired) {
 			// Log JWT expiration as info

--- a/sessions_test.go
+++ b/sessions_test.go
@@ -1,0 +1,165 @@
+package postauth2fa
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func TestCreateOrUpdateJWTCookieSetsExpectedCookie(t *testing.T) {
+	t.Parallel()
+
+	m := newTestModule(t)
+	m.CookieDomain = "example.com"
+
+	rec := httptest.NewRecorder()
+	m.createOrUpdateJWTCookie(rec, "alice", "203.0.113.10")
+
+	res := rec.Result()
+	cookies := res.Cookies()
+	if len(cookies) != 1 {
+		t.Fatalf("cookies len = %d, want 1", len(cookies))
+	}
+
+	cookie := cookies[0]
+	if cookie.Name != m.CookieName ||
+		cookie.Path != m.CookiePath ||
+		cookie.Domain != m.CookieDomain ||
+		!cookie.HttpOnly ||
+		!cookie.Secure ||
+		cookie.SameSite != http.SameSiteStrictMode {
+		t.Fatalf("unexpected cookie: %+v", cookie)
+	}
+
+	token, err := jwt.Parse(cookie.Value, func(token *jwt.Token) (any, error) {
+		return m.signKeyBytes, nil
+	}, jwt.WithValidMethods([]string{"HS256"}))
+	if err != nil {
+		t.Fatalf("parse cookie token: %v", err)
+	}
+
+	claims := token.Claims.(jwt.MapClaims)
+	if claims["username"] != "alice" {
+		t.Fatalf("username claim = %v, want alice", claims["username"])
+	}
+	if claims["clientIP"] != "203.0.113.10" {
+		t.Fatalf("clientIP claim = %v, want 203.0.113.10", claims["clientIP"])
+	}
+	if int64(claims["iat"].(float64)) != m.now().Unix() {
+		t.Fatalf("iat = %v, want %d", claims["iat"], m.now().Unix())
+	}
+	if int64(claims["exp"].(float64)) != m.now().Add(m.SessionInactivityTimeout).Unix() {
+		t.Fatalf("exp = %v, want %d", claims["exp"], m.now().Add(m.SessionInactivityTimeout).Unix())
+	}
+}
+
+func TestHasValidJWTCookie(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, time.January, 2, 15, 4, 5, 0, time.UTC)
+
+	tests := []struct {
+		name          string
+		username      string
+		clientIP      string
+		tokenUsername string
+		tokenClientIP string
+		ipBinding     string
+		expOffset     time.Duration
+		wantValid     bool
+		wantSetCookie bool
+	}{
+		{
+			name:          "accepts valid token",
+			username:      "alice",
+			clientIP:      "203.0.113.10",
+			tokenUsername: "alice",
+			tokenClientIP: "203.0.113.10",
+			ipBinding:     "true",
+			expOffset:     45 * time.Minute,
+			wantValid:     true,
+		},
+		{
+			name:          "rejects mismatched username",
+			username:      "alice",
+			clientIP:      "203.0.113.10",
+			tokenUsername: "bob",
+			tokenClientIP: "203.0.113.10",
+			ipBinding:     "true",
+			expOffset:     45 * time.Minute,
+		},
+		{
+			name:          "rejects mismatched ip when binding enabled",
+			username:      "alice",
+			clientIP:      "203.0.113.10",
+			tokenUsername: "alice",
+			tokenClientIP: "203.0.113.11",
+			ipBinding:     "true",
+			expOffset:     45 * time.Minute,
+		},
+		{
+			name:          "accepts mismatched ip when binding disabled",
+			username:      "alice",
+			clientIP:      "203.0.113.10",
+			tokenUsername: "alice",
+			tokenClientIP: "203.0.113.11",
+			ipBinding:     "false",
+			expOffset:     45 * time.Minute,
+			wantValid:     true,
+		},
+		{
+			name:          "rejects expired token",
+			username:      "alice",
+			clientIP:      "203.0.113.10",
+			tokenUsername: "alice",
+			tokenClientIP: "203.0.113.10",
+			ipBinding:     "true",
+			expOffset:     -time.Minute,
+		},
+		{
+			name:          "extends nearly expired session",
+			username:      "alice",
+			clientIP:      "203.0.113.10",
+			tokenUsername: "alice",
+			tokenClientIP: "203.0.113.10",
+			ipBinding:     "true",
+			expOffset:     10 * time.Minute,
+			wantValid:     true,
+			wantSetCookie: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newTestModule(t)
+			m.timeNow = func() time.Time {
+				return now
+			}
+
+			req := newRequestWithContext(http.MethodGet, "https://example.com/secure", tt.username, "/secure", tt.clientIP, "198.51.100.30:1234", nil)
+			req.AddCookie(&http.Cookie{
+				Name: m.CookieName,
+				Value: signedTokenString(t, m, jwt.MapClaims{
+					"username": tt.tokenUsername,
+					"clientIP": tt.tokenClientIP,
+					"iat":      now.Add(-5 * time.Minute).Unix(),
+					"exp":      now.Add(tt.expOffset).Unix(),
+				}),
+			})
+
+			rec := httptest.NewRecorder()
+			got := m.hasValidJWTCookie(rec, req, tt.username, tt.clientIP, tt.ipBinding)
+			if got != tt.wantValid {
+				t.Fatalf("hasValidJWTCookie() = %v, want %v", got, tt.wantValid)
+			}
+
+			hasSetCookie := rec.Header().Get("Set-Cookie") != ""
+			if hasSetCookie != tt.wantSetCookie {
+				t.Fatalf("Set-Cookie present = %v, want %v", hasSetCookie, tt.wantSetCookie)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds focused unit test coverage for the plugin’s core security and configuration paths, and makes time-dependent JWT/TOTP behavior deterministic in tests.

It also restricts Dependabot updates to direct dependencies only.

## Changes

- add unit tests for:
  - `Validate()`
  - `Provision()`
  - `UnmarshalCaddyfile()`
  - `ServeHTTP()`
  - `getSecretForUser()`
  - `createOrUpdateJWTCookie()`
  - `hasValidJWTCookie()`
- add deterministic time handling for JWT/TOTP-related tests
- make JWT validation use the module’s injected time source consistently
- use Caddy test helpers for request setup in tests
- restrict Dependabot updates to direct dependencies

## Why

These paths contain most of the plugin’s security-sensitive and regression-prone behavior:
- 2FA request flow
- JWT session handling
- secret loading/decryption
- config parsing and provisioning

The added coverage should reduce regression risk and make future refactoring safer.

## Verification

- `go test -v ./...` passes locally
